### PR TITLE
Ignore using named colors inside sass functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,12 @@ module.exports = {
     'block-opening-brace-space-before': 'always-single-line',
     'color-hex-case': 'lower',
     'color-hex-length': 'short',
-    'color-named': 'never',
+    'color-named': [
+      'never',
+      {
+        ignore: ["inside-function"]
+      }
+    ],
     'color-no-invalid-hex': true,
     'comment-empty-line-before': 'always',
     'comment-no-empty': true,


### PR DESCRIPTION
For example, I'd like to be able to do this:

`color: map-get($colors, white);`

See https://stylelint.io/user-guide/rules/color-named/#ignore-inside-function